### PR TITLE
Palindrome Products (Python) and Airport Robot (GO)

### DIFF
--- a/go/airport-robot/airport_robot.go
+++ b/go/airport-robot/airport_robot.go
@@ -1,0 +1,35 @@
+package airportrobot
+
+import "fmt"
+
+// Write your code here.
+// This exercise does not have tests for each individual task.
+// Try to solve all the tasks first before running the tests.
+type Greeter interface {
+	LanguageName() string
+	Greet(name string) string
+}
+
+func SayHello(name string, greeter Greeter) string {
+	return fmt.Sprintf("I can speak %s: %s", greeter.LanguageName(), greeter.Greet(name))
+}
+
+type Italian struct{}
+
+func (italian Italian) LanguageName() string {
+	return "Italian"
+}
+
+func (italian Italian) Greet(name string) string {
+	return fmt.Sprintf("Ciao %s!", name)
+}
+
+type Portuguese struct{}
+
+func (portuguese Portuguese) LanguageName() string {
+	return "Portuguese"
+}
+
+func (portuguese Portuguese) Greet(name string) string {
+	return fmt.Sprintf("Olá %s!", name)
+}

--- a/python/palindrome-products/palindrome_products.py
+++ b/python/palindrome-products/palindrome_products.py
@@ -1,0 +1,72 @@
+"""
+Find the smallest and largest palindrome products for a range of numbers.
+"""
+
+def largest(min_factor, max_factor):
+    """Given a range of numbers, find the largest palindromes which
+       are products of two numbers within that range.
+
+    :param min_factor: int with a default value of 0
+    :param max_factor: int
+    :return: tuple of (palindrome, iterable).
+             Iterable should contain both factors of the palindrome in an arbitrary order.
+    """
+    return palindrome_product_helper(min_factor, max_factor, max)
+
+
+def smallest(min_factor, max_factor):
+    """Given a range of numbers, find the smallest palindromes which
+    are products of two numbers within that range.
+
+    :param min_factor: int with a default value of 0
+    :param max_factor: int
+    :return: tuple of (palindrome, iterable).
+    Iterable should contain both factors of the palindrome in an arbitrary order.
+    """
+    return palindrome_product_helper(min_factor, max_factor, min)
+
+def palindrome_product_helper(min_factor, max_factor, compare_fn):
+    """Given a range of numbers, find the palindromes matching the result of the function fn
+    which are products of two numbers within that range.
+    :param min_factor: int with a default value of 0
+    :param max_factor: int
+    :param compare_fn: function to determine palindrome products to keep
+    :return: tuple of (palindrome, iterable).
+    Iterable should contain both factors of the palindrome in an arbitrary order.
+    """
+    if min_factor > max_factor:
+        raise ValueError('min must be <= max')
+
+    products = []
+    target_value = None
+
+    if compare_fn(1, 2) == 2:
+        # Bigger first
+        start = max_factor
+        stop = min_factor - 1
+        step = -1
+    else:
+        # Smaller first
+        start = min_factor
+        stop = max_factor + 1
+        step = 1
+
+    for outer in range(start, stop, step):
+        if step > 0:
+            inner_start = outer
+            inner_stop = max_factor + 1
+        else:
+            inner_start = max_factor
+            inner_stop = outer - 1
+        for inner in range(inner_start, inner_stop, step):
+            product = inner * outer 
+            if target_value is not None and compare_fn(product, target_value) != product:
+                continue
+            digits = str(inner * outer)
+            if digits == digits[::-1]:
+                target_value = product
+                products.append((inner, outer))
+
+    if len(products) == 0:
+        return None, ()
+    return target_value, (pair for pair in products if pair[0] * pair[1] == target_value)


### PR DESCRIPTION
Palindrome Product kept timing out because they want fast runtime but slow number ranges, had to redo it too many times, taking too much time.

Don't know why the interface for the Airport Robots required the objects to not be pointers is that a method thing, an interface thing, or am I just missing something.